### PR TITLE
Reformatting of README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # Introduction
-Basic haXe Bundle for Sublime Text 2 (http://www.sublimetext.com/2)
+Basic haXe Bundle for [Sublime Text 2](http://www.sublimetext.com/2)
 
 # Installation
 ## Mac OSX


### PR DESCRIPTION
I made some reformatting in the README.

Descriptions with had an URL in plaintext after them are now converted into links
