### PR TITLE
fix: Escaped forward slashes in regex won't break syntax coloring

### DIFF
--- a/HaXe.tmLanguage
+++ b/HaXe.tmLanguage
@@ -24,6 +24,10 @@
     </dict>
     <dict>
       <key>include</key>
+      <string>#regex</string>
+    </dict>
+    <dict>
+      <key>include</key>
       <string>#strings</string>
     </dict>
     <dict>
@@ -49,10 +53,6 @@
     <dict>
       <key>include</key>
       <string>#keywords</string>
-    </dict>
-    <dict>
-      <key>include</key>
-      <string>#regex</string>
     </dict>
     <dict>
       <key>include</key>
@@ -408,10 +408,10 @@
       <key>patterns</key>
       <array>
         <dict>
-          <key>captures</key>
-          <dict/>
+          <key>name</key>
+          <string>support.regex.haxe.2</string>
           <key>match</key>
-          <string>~/([^/]+)/</string>
+          <string>~/((?:\\/|[^/])+)/</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
This fixes syntax coloring for regex lines that have an escaped forward slash or quote in it. I set the name to "support.regex.haxe.2" as well but I'm not sure that's what it should be.
