### PR TITLE
Find the root folder in a slightly better way.

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -890,9 +890,12 @@ class HaxeComplete( sublime_plugin.EventListener ):
 		folder = os.path.dirname(fn)
 		
 		folders = view.window().folders()
-		for f in folders:
-			if f + "/" in fn :
-				folder = f
+		if len(folders) == 1:
+			folder = folders[0]
+		else:
+			for f in folders:
+				if f + "/" in fn :
+					folder = f
 
 		# settings.set("haxe-complete-folder", folder)
 		self.find_hxml(folder)


### PR DESCRIPTION
HaxeComplete used to assume that the root folder of the project was the
folder that the current file was in, which is not generally true. The code
here works for the case where you only have one root folder open in
Sublime - it assume that's the root folder and searches for *.nmml files
in it. If you have more than one, it reverts to the old way of looking
around where your file is, which is probably what you intended if you have
multiple folders. However this could still be improved.
