### PR TITLE
Allow hxml files with missing -main classes to be included in builds

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -874,8 +874,9 @@ class HaxeComplete( sublime_plugin.EventListener ):
 				currentBuild.classpaths.append( buildPath )
 				currentBuild.args.append( ("-cp" , buildPath ) )
 			
-			if currentBuild.main is not None :
-				self.builds.append( currentBuild )
+			if currentBuild.main is None:
+			    currentBuild.main = '[No Main]'
+                        self.builds.append( currentBuild )
 
 
 


### PR DESCRIPTION
This pull request allows hxml files missing a -main flag to be included in the hxml options for builds and completions.  It gives them a simple title of [No Main] inside of the selection options.  Check issue #76 for more details.
