### PR TITLE
Fixing colorization

### DIFF
--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -447,7 +447,7 @@
             </dict>
           </dict>
           <key>match</key>
-          <string>(\b(([a-z]+\.)*)([A-Z]\w*))</string>
+          <string>(\b(([a-z]+\.)*)([A-Z]\w*|\*))</string>
         </dict>
         <dict>
           <key>name</key>


### PR DESCRIPTION
Fixed some minor colorization issues with #elseif, wildcard packages, and calling new with multiple type arguments. See below:

``` haxe
#if condition
#elseif (foo || bar)
#end
```

``` haxe
import foo.bar.*;
```

``` haxe
var secondNowHighlights = new MyType<First, Second>();
```
