### PR TITLE
Fix build select with multiple folders on Windows

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -822,7 +822,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
                 folder = folders[0]
             else:
                 for f in folders:
-                    if f + "/" in fn :
+                    if f + os.sep in fn :
                         folder = f
 
         if folder is not None :


### PR DESCRIPTION
In Windows, when you had multiple folders open, this would fail to match the folder the file currently open resides in, causing it to be unable to detect a pre-existing project.xml, for instance.

Using the platform-agnostic os.sep fixed this issue.
