### PR TITLE
Include <haxedef> nodes for nme/lime/openfl projects in the args list

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -665,6 +665,8 @@ class HaxeComplete( sublime_plugin.EventListener ):
                     elif (tag == "haxelib"):
                         currentBuild.libs.append( HaxeLib.get( name ) )
                         currentBuild.args.append( ("-lib" , name) )
+                    elif (tag == "haxedef"):
+                        currentBuild.args.append( ("-D", name) )
                     elif (tag == "classpath" or tag == "source"):
                         currentBuild.classpaths.append( os.path.join( buildPath , name ) )
                         currentBuild.args.append( ("-cp" , os.path.join( buildPath , name ) ) )


### PR DESCRIPTION
We have a pretty big project for which autocompletion has been broken for an age. It turns out that the problem is that we have a haxedef defined in our project.xml file that is currently needed for the project to compile correctly, but that wasn't currently being passed as an arg into the compiler when getting the autocompletion data. 

So, this change fixes that by including all <haxedef> nodes as -D xxxx in the args list.
