### PR TITLE
Ensure files have write permissions when necessary during temp file creation/deletion

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -8,6 +8,7 @@ import sublime, sublime_plugin
 import subprocess, time
 import tempfile
 import os, signal
+import stat
 
 #import xml.parsers.expat
 import re
@@ -1774,7 +1775,6 @@ class HaxeComplete( sublime_plugin.EventListener ):
 
 
     def save_temp_file( self , view ) :
-
         fn = view.file_name()
 
         tdir = os.path.dirname(fn)
@@ -1786,10 +1786,15 @@ class HaxeComplete( sublime_plugin.EventListener ):
             os.mkdir( tdir )
 
         if os.path.exists( fn ):
+            if os.path.exists( temp ):
+                shutil.copy2( temp , fn )
+                os.chmod( temp, stat.S_IWRITE )
+                os.remove( temp )
             # copy saved file to temp for future restoring
             shutil.copy2( fn , temp )
 
         # write current source to file
+        os.chmod( fn, stat.S_IWRITE )
         f = codecs.open( fn , "wb" , "utf-8" , "ignore" )
         f.write( src )
         f.close()
@@ -1797,11 +1802,11 @@ class HaxeComplete( sublime_plugin.EventListener ):
         return temp
 
     def clear_temp_file( self , view , temp ) :
-
         fn = view.file_name()
 
         if os.path.exists( temp ) :
             shutil.copy2( temp , fn )
+            os.chmod( temp, stat.S_IWRITE )
             os.remove( temp )
         else:
             # fn didn't exist in the first place, so we remove it


### PR DESCRIPTION
My proposed solution to the issue I outlined in https://github.com/clemos/haxe-sublime-bundle/issues/180. Everything still seems to be working, but there's no more error message or *.tmp files popping up everywhere.
