### PR TITLE
add support for `type` display mode

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -1553,6 +1553,8 @@ class HaxeComplete( sublime_plugin.EventListener ):
         if display["commas"] is not None :
             commas = display["commas"]
 
+        mode = display["mode"]
+
         if int(sublime.version()) >= 3000 :
             x = "<root>"+err+"</root>"
         else :
@@ -1568,6 +1570,10 @@ class HaxeComplete( sublime_plugin.EventListener ):
         if tree is not None :
             for i in tree.getiterator("type") :
                 hint = i.text.strip()
+
+                if mode == "type":
+                    return hint
+
                 spl = hint.split(" -> ")
 
                 types = [];
@@ -1686,10 +1692,13 @@ class HaxeComplete( sublime_plugin.EventListener ):
 
             self.errors = self.extract_errors( err, cwd )
 
-        if display["mode"] == "position":
+        if mode == "type":
+            return None # this should have returned earlier
+
+        if mode == "position":
             return pos
-        else:
-            return ( err, comps, status , hints )
+
+        return ( err, comps, status , hints )
 
     def extract_errors( self , str , cwd ):
         errors = []

--- a/Support/Context.sublime-menu
+++ b/Support/Context.sublime-menu
@@ -1,7 +1,12 @@
-[  
-{  
-    "id": "haxe-goto-definition",  
-    "caption" : "Goto definition (Haxe)",
-    "command" : "haxe_find_definition"
-}
-]  
+[
+    {
+        "id": "haxe-goto-definition",
+        "caption": "Goto definition (Haxe)",
+        "command": "haxe_find_definition"
+    },
+    {
+        "id": "haxe-show-type",
+        "caption": "Show type (Haxe)",
+        "command": "haxe_show_type"
+    }
+]

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -5,6 +5,7 @@ from .haxe_restart_server import HaxeRestartServer
 from .haxe_create_type import HaxeCreateType
 from .haxe_generate_import import HaxeGenerateImport
 from .haxe_find_definition import HaxeFindDefinition
+from .haxe_show_type import HaxeShowType
 from .haxe_add_hxml import HaxeAddHxml
 
 print("Haxe : Reloading haxe module")
@@ -14,5 +15,6 @@ __all__ = [
     'HaxeCreateType',
     'HaxeGenerateImport',
     'HaxeFindDefinition',
-    'HaxeAddHxml'
+    'HaxeAddHxml',
+    'HaxeShowType',
 ]

--- a/features/haxe_show_type.py
+++ b/features/haxe_show_type.py
@@ -1,0 +1,40 @@
+import codecs
+import sublime
+import sublime_plugin
+
+try: # Python 3
+    from ..HaxeHelper import HaxeComplete_inst
+except (ValueError): # Python 2
+    from HaxeHelper import HaxeComplete_inst
+
+class HaxeShowType( sublime_plugin.TextCommand ):
+
+    def run( self , edit ) :
+
+        view = self.view
+
+        # get word under cursor
+        word = view.word(view.sel()[0])
+
+        # get utf-8 byte offset to the end of the word
+        src = view.substr(sublime.Region(0, word.b))
+        offset = len(codecs.encode(src, "utf-8")) + 1 # add 1 because offset is 1-based
+
+        complete = HaxeComplete_inst()
+
+        # save file and run completion
+        temp = complete.save_temp_file( view )
+        hint = complete.run_haxe(view, dict(
+            mode="type",
+            filename=view.file_name(),
+            offset=offset,
+            commas=None
+        ))
+        complete.clear_temp_file( view , temp )
+
+        if hint is None:
+            status = "No type information for '" + view.substr(sublime.Region(word.a, word.b)) + "'."
+            self.view.set_status( "haxe-status", status )
+        else :
+            self.view.show_popup_menu([hint], lambda i: None)
+            self.view.set_status( "haxe-status", hint )


### PR DESCRIPTION
This PR adds a command to display a type of expression under the caret.
Only supported in latest Haxe, see https://github.com/HaxeFoundation/haxe/pull/3622
