### PR TITLE
Improving package pattern matching

### DIFF
--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -521,7 +521,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(package)(\s+[a-z\._]*);</string>
+          <string>\b(package)\s*((?:[a-z][a-z0-9_]*\.)*[a-z][a-z0-9_]*)?;</string>
           <key>captures</key>
           <dict>
             <key>1</key>


### PR DESCRIPTION
Improving package pattern matching so that it more closely matches what Haxe allows.

* Numbers are allowed as long as the package doesn't start with them.
* Periods are not allowed at the beginning or end of packages.
* An empty package can be denoted with `package;` not requiring a space between package and the semicolon.

### Valid patterns
```haxe
package;
package foo;
package foo.bar.baz;
package foo1.bar;
```
### Invalid patterns
```haxe
package foo.bar.;
package foo.2bar;
package .foo.bar;
```

Interestingly enough even GitHub gets it wrong...