### PR TITLE
Improved `read_hxml`.

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -796,6 +796,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
                         if len( spl ) == 2 :
                             lib = HaxeLib.get( spl[1] )
                             currentBuild.libs.append( lib )
+                            currentBuild.args.append( spl )
                         else :
                             sublime.status_message( "Invalid build.hxml : lib not found" )
 
@@ -807,7 +808,6 @@ class HaxeComplete( sublime_plugin.EventListener ):
                     #   currentBuild.args.append( ( "--connect" , str(self.serverPort) ))
 
                     elif [l for flag in [
-                        "lib" ,
                         "D" ,
                         "swf-version" ,
                         "swf-header",


### PR DESCRIPTION
This is quite a big revision of the `read_hxml` function.
Hopefully it wouldn't break anything... Please review and test with your projects. ;)

Here is the list of improvements:
 * Correctly handle nested hxml files.
 * Recognise haxe class being passed without `-main`.
 * Gracefully handle unknown compiler arguments - show warning status message and then add them anyway.
 * Use `l.split(" ", 1)` instead of (`l.split(" ")` + `join`).