### PR TITLE
hint improvements

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -373,72 +373,6 @@ class HaxeSelectBuild( sublime_plugin.TextCommand ):
         complete.select_build( view )
 
 
-class HaxeHint( sublime_plugin.TextCommand ):
-    def run( self , edit , input = "" ) :
-        complete = HaxeComplete.inst
-        view = self.view
-
-        if input == "(":
-            sel = view.sel()
-            emptySel = True
-            for r in sel :
-                if not r.empty() :
-                    emptySel = False
-                    break
-
-            autoMatch = view.settings().get("auto_match_enabled",False)
-
-            if autoMatch :
-                if emptySel :
-                    view.run_command( "insert_snippet" , {
-                        "contents" : "($0)"
-                    })
-                else :
-                    view.run_command( "insert_snippet" , {
-                        "contents" : "(${0:$SELECTION})"
-                    })
-            else :
-                view.run_command("insert" , {
-                    "characters" : "("
-                })
-        else :
-            view.run_command("insert" , {
-                "characters" : input
-            })
-
-        autocomplete = view.settings().get("auto_complete",True)
-        if not autocomplete :
-            return
-
-        for r in view.sel() :
-            comps, hints = complete.get_haxe_completions( self.view , r.end() )
-
-            fn_name = complete.get_current_fn_name(self.view, r.end())
-
-            if view.settings().get("haxe_smart_snippets",False) :
-                snippet = ""
-                i = 1
-                for h in hints :
-                    var = str(i)+": " + h + " ";
-                    var = var.replace("{","\{")
-                    var = var.replace("}","\}")
-                    if snippet == "":
-                        snippet = var
-                    else:
-                        snippet = snippet + ",${" + var + "}"
-                    i = i+1
-
-                #print( hints )
-                view.run_command( "insert_snippet" , {
-                    "contents" : "${"+snippet+"}"
-                })
-
-            #view.set_status("haxe-status", status)
-            #sublime.status_message(status)
-            #if( len(comps) > 0 ) :
-            #   view.run_command('auto_complete', {'disable_auto_insert': True})
-
-
 class HaxeComplete( sublime_plugin.EventListener ):
 
     #folder = ""
@@ -1664,9 +1598,6 @@ class HaxeComplete( sublime_plugin.EventListener ):
             for i in tree.getiterator("type") :
                 hint = i.text.strip()
 
-                if mode == "type":
-                    return hint
-
                 spl = hint.split(" -> ")
 
                 types = [];
@@ -1684,7 +1615,19 @@ class HaxeComplete( sublime_plugin.EventListener ):
                         types.append( " -> ".join( currentType ) )
                         currentType = []
 
+                for i in range(0, len(types)):
+                    types[i] = types[i].replace('(', '')
+                    types[i] = types[i].replace(')', '')
+
                 ret = types.pop()
+
+                if mode == "type":
+                    hint = ret
+                    if types:
+                        hint = ','.join(types)
+                        hint = '(%s):%s' % (hint, ret)
+                    return hint
+
                 msg = "";
 
                 if commas >= len(types) :

--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -1178,7 +1178,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
                 else :
                     tarPkg = "flash8"
 
-        if not build.openfl and not build.lime and build.nmml is not None or HaxeLib.get("nme") in build.libs :
+        if not build.openfl and not build.lime and build.nmml is not None or "nme" in HaxeLib.available and HaxeLib.get("nme") in build.libs :
             tarPkg = "nme"
             targetPackages.extend( ["jeash","neash","browser","native"] )
 
@@ -1969,11 +1969,16 @@ class HaxeComplete( sublime_plugin.EventListener ):
             if prevSymbol == prevComa:
                 closedPars = 0
                 closedBrackets = 0
+                closedSquares = 0
 
                 for i in range( prevComa , 0 , -1 ) :
                     c = src[i]
 
-                    if c == ")" :
+                    if c == "]" :
+                        closedSquares += 1
+                    elif c == "[" :
+                        closedSquares -= 1
+                    elif c == ")" :
                         closedPars += 1
                     elif c == "(" :
                         if closedPars < 1 :
@@ -1982,7 +1987,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
                         else :
                             closedPars -= 1
                     elif c == "," :
-                        if closedPars == 0 and closedBrackets == 0 :
+                        if closedPars == 0 and closedBrackets == 0 and closedSquares == 0:
                             commas += 1
                     elif c == "{" : # TODO : check for { ... , ... , ... } to have the right comma count
                         closedBrackets -= 1
@@ -1995,7 +2000,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
                 #print("commas : " + str(commas))
                 #print("closedBrackets : " + str(closedBrackets))
                 #print("closedPars : " + str(closedPars))
-                if closedBrackets < 0 :
+                if closedBrackets < 0 or closedSquares < 0 :
                     show_hints = False
             else :
 
@@ -2008,11 +2013,11 @@ class HaxeComplete( sublime_plugin.EventListener ):
 
         toplevelComplete = toplevelComplete or completeChar in ":(," or inControlStruct
 
-        if toplevelComplete :
+        # if toplevelComplete :
             #print("toplevel")
-            offset = userOffset
-        else :
-            offset = completeOffset
+        #     offset = userOffset
+        # else :
+        offset = completeOffset
             #print(comps)
 
         if src[offset-1]=="." and src[offset-2] in ".1234567890" :

--- a/Support/Default.sublime-keymap
+++ b/Support/Default.sublime-keymap
@@ -171,6 +171,28 @@
         "args" : {"add" : true, "sort" : true, "remove" : true, "auto_remove" : false}
     },
     {
+        "keys": ["ctrl+shift+h","ctrl+shift+p"],
+        "command": "haxe_hint",
+        "context": [
+            {
+                "key": "selector",
+                "operator": "equal",
+                "operand": "source.haxe.2 meta.parameters.haxe.2"
+            }
+        ]
+    },
+    {
+        "keys": ["ctrl+shift+h","ctrl+shift+p"],
+        "command": "haxe_show_type",
+        "context": [
+            {
+                "key": "selector",
+                "operator": "not_equal",
+                "operand": "source.haxe.2 meta.parameters.haxe.2"
+            }
+        ]
+    },
+    {
         "keys": ["ctrl+shift+f1"],
         "command" : "haxe_show_documentation",
         "args" : {}

--- a/Support/Haxe.sublime-settings
+++ b/Support/Haxe.sublime-settings
@@ -31,7 +31,12 @@
 	*/
 	"haxe_whitespace_style" : "function f(a:T<T>, b:T = null):T->T;",
 	
-	"haxe_use_cache" : true
+	"haxe_use_cache" : true,
+	
+	/*
+		Use popups in Sublime Text 3 (build >= 3070)
+	*/
+	"haxe_use_popup" : true
 	
 	// ,"haxe_path" : "/usr/bin/haxe"
 	// ,"haxe_library_path" : "/usr/local/haxe/std:."

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -11,6 +11,7 @@ from .haxe_generate_code import HaxeGenerateCode
 from .haxe_generate_code_helper import HaxeGenerateCodeEdit
 from .haxe_generate_field import HaxeGenerateField
 from .haxe_extract_var import HaxeExtractVar
+from .haxe_hint import HaxeHint, HaxeShowPopup, HaxeColorScheme
 from .haxe_implement_interface import HaxeImplementInterface
 from .haxe_organize_imports import HaxeOrganizeImports, HaxeOrganizeImportsEventListener, HaxeOrganizeImportsEdit
 
@@ -31,4 +32,7 @@ __all__ = [
     'HaxeExtractVar',
     'HaxeImplementInterface',
     'HaxeGenerateCode',
+    'HaxeColorScheme',
+    'HaxeShowPopup',
+    'HaxeHint',
 ]

--- a/features/haxe_hint.py
+++ b/features/haxe_hint.py
@@ -1,0 +1,196 @@
+import os
+import sublime
+import sublime_plugin
+
+if int(sublime.version()) >= 3000:
+    from plistlib import readPlistFromBytes
+else:
+    from plistlib import readPlist
+
+try:  # Python 3
+    from ..HaxeHelper import HaxeComplete_inst
+    from .haxe_generate_code_helper import format_statement
+except (ValueError):  # Python 2
+    from HaxeHelper import HaxeComplete_inst
+    from haxe_generate_code_helper import format_statement
+
+
+class HaxeColorScheme(sublime_plugin.EventListener):
+
+    def __init__(self):
+        self.inited = False
+
+    def init(self, view):
+        if view.score_selector(0, 'source.haxe.2') == 0:
+            return
+
+        self.inited = True
+        view.settings().add_on_change('color_scheme', self.on_scheme_change)
+        self.on_scheme_change()
+
+    @staticmethod
+    def get_color(name):
+        if HaxeColorScheme.color_map is None or \
+                name not in HaxeColorScheme.color_map:
+            return None
+        return HaxeColorScheme.color_map[name]
+
+    @staticmethod
+    def get_styles():
+        if HaxeColorScheme.styles is None:
+            if HaxeColorScheme.color_map is None:
+                return ''
+
+            colors = (
+                HaxeColorScheme.get_color('popupBackground') or
+                HaxeColorScheme.get_color('lineHighlight') or
+                HaxeColorScheme.get_color('background'),
+                HaxeColorScheme.get_color('popupForeground') or
+                HaxeColorScheme.get_color('foreground'))
+            HaxeColorScheme.styles = \
+                '<style>html{background-color:%s;color:%s;}</style>' % colors
+
+        return HaxeColorScheme.styles
+
+    def on_activated(self, view):
+        if not self.inited:
+            self.init(view)
+
+    def on_scheme_change(self):
+        HaxeColorScheme.styles = None
+        HaxeColorScheme.color_map = None
+        view = sublime.active_window().active_view()
+
+        color_scheme = view.settings().get('color_scheme')
+
+        try:
+            if int(sublime.version()) >= 3000:
+                b = sublime.load_binary_resource(color_scheme)
+                pl = readPlistFromBytes(b)
+            else:
+                pl = readPlist(os.path.join(os.path.abspath(
+                    sublime.packages_path() + '/..'), color_scheme))
+        except:
+            return
+
+        def safe_update(fr, to):
+            for k in fr.keys():
+                if k not in to:
+                    to[k] = fr[k]
+
+        dct = {}
+        for d in pl.settings:
+            if 'settings' not in d:
+                continue
+            s = d['settings']
+            if 'scope' not in d:
+                safe_update(s, dct)
+            elif 'text' in d['scope'] or 'source' in d['scope']:
+                dct.update(d.settings)
+
+        HaxeColorScheme.color_map = dct
+
+    def on_load(self, view):
+        if not self.inited:
+            self.init(view)
+
+
+class HaxeShowPopup(sublime_plugin.TextCommand):
+
+    def run(self, edit, text=None):
+        view = self.view
+        if not text:
+            return
+
+        view.show_popup(
+            HaxeColorScheme.get_styles() + text,
+            max_width=700)
+
+
+class HaxeHint(sublime_plugin.TextCommand):
+
+    def run(self, edit, input=''):
+        complete = HaxeComplete_inst()
+        view = self.view
+
+        if input == '(':
+            sel = view.sel()
+            emptySel = True
+            for r in sel:
+                if not r.empty():
+                    emptySel = False
+                    break
+
+            autoMatch = view.settings().get('auto_match_enabled', False)
+
+            if autoMatch:
+                if emptySel:
+                    view.run_command('insert_snippet', {
+                        'contents': '($0)'
+                    })
+                else:
+                    view.run_command('insert_snippet', {
+                        'contents': '(${0:$SELECTION})'
+                    })
+            else:
+                view.run_command('insert', {
+                    'characters': '('
+                })
+        else:
+            view.run_command('insert', {
+                'characters': input
+            })
+
+        autocomplete = view.settings().get('auto_complete', True)
+        if not autocomplete:
+            return
+
+        haxe_smart_snippets = view.settings().get('haxe_smart_snippets', False)
+        haxe_use_popup = view.settings().get('haxe_use_popup', True) and \
+            int(sublime.version()) >= 3070
+
+        if not haxe_smart_snippets and not haxe_use_popup:
+            return
+
+        for r in view.sel():
+            comps, hints = complete.get_haxe_completions(self.view, r.end())
+
+            if haxe_use_popup:
+                self.show_popup(hints)
+            elif haxe_smart_snippets:
+                self.show_snippet(hints)
+
+    def show_popup(self, hints):
+        view = self.view
+        text = ''
+
+        for h in hints:
+            if not text:
+                text = '{}%s{}' % h
+            else:
+                text += ',%s' % h
+
+        text = format_statement(view, text)
+        text = text.format('<b>', '</b>')
+
+        view.run_command('haxe_show_popup', {
+            'text': text
+        })
+
+    def show_snippet(self, hints):
+        view = self.view
+        snippet = ''
+        i = 1
+        for h in hints:
+            var = '%d:%s' % (i, h)
+            if snippet == '':
+                snippet = var
+            else:
+                snippet += ',${%s}' % var
+            i += 1
+
+        snippet = format_statement(view, snippet)
+
+        view.run_command('insert_snippet', {
+            'contents': '${' + snippet + '}'
+        })

--- a/features/haxe_show_type.py
+++ b/features/haxe_show_type.py
@@ -2,39 +2,52 @@ import codecs
 import sublime
 import sublime_plugin
 
-try: # Python 3
+try:  # Python 3
     from ..HaxeHelper import HaxeComplete_inst
-except (ValueError): # Python 2
+    from .haxe_generate_code_helper import format_statement
+except (ValueError):  # Python 2
     from HaxeHelper import HaxeComplete_inst
+    from haxe_generate_code_helper import format_statement
 
-class HaxeShowType( sublime_plugin.TextCommand ):
 
-    def run( self , edit ) :
+class HaxeShowType(sublime_plugin.TextCommand):
 
+    def run(self, edit):
         view = self.view
+
+        if view.score_selector(0, 'source.haxe.2') == 0 or \
+                int(sublime.version()) < 3000:
+            return
 
         # get word under cursor
         word = view.word(view.sel()[0])
 
         # get utf-8 byte offset to the end of the word
         src = view.substr(sublime.Region(0, word.b))
-        offset = len(codecs.encode(src, "utf-8")) + 1 # add 1 because offset is 1-based
+        offset = len(codecs.encode(src, "utf-8")) + 1
+        # add 1 because offset is 1-based
 
         complete = HaxeComplete_inst()
 
         # save file and run completion
-        temp = complete.save_temp_file( view )
+        temp = complete.save_temp_file(view)
         hint = complete.run_haxe(view, dict(
             mode="type",
             filename=view.file_name(),
             offset=offset,
             commas=None
         ))
-        complete.clear_temp_file( view , temp )
+        complete.clear_temp_file(view, temp)
 
         if hint is None:
-            status = "No type information for '" + view.substr(sublime.Region(word.a, word.b)) + "'."
-            self.view.set_status( "haxe-status", status )
-        else :
-            self.view.show_popup_menu([hint], lambda i: None)
-            self.view.set_status( "haxe-status", hint )
+            status = "No type information for '%s'." % \
+                view.substr(sublime.Region(word.a, word.b))
+            view.set_status("haxe-status", status)
+        else:
+            hint = format_statement(view, hint)
+            if int(sublime.version()) >= 3070 and \
+                    view.settings().get("haxe_use_popup", True):
+                view.run_command('haxe_show_popup', {'text': hint})
+            else:
+                view.show_popup_menu([hint], lambda i: None)
+            view.set_status("haxe-status", hint)


### PR DESCRIPTION
fix #146
![out](https://cloud.githubusercontent.com/assets/11094615/6859481/4834e054-d42a-11e4-91b7-a90b73465fbe.gif)

*haxe_show_type* command (sublime text 3 build >= 3070)
![out](https://cloud.githubusercontent.com/assets/11094615/6871025/d50cf580-d4b0-11e4-85d1-cbb1802aec7b.gif)

*haxe_hint* (sublime text 3 build >= 3070)
![out2](https://cloud.githubusercontent.com/assets/11094615/6871028/da209bda-d4b0-11e4-832f-e5d44f30f0c8.gif)

Press *ctrl+shift+h, ctrl+shift+p*
![out](https://cloud.githubusercontent.com/assets/11094615/6874841/6eefa660-d4cb-11e4-9b97-19229221f1ee.gif)

You can disable popups in settings:
```json
"haxe_use_popup" : false
```

You can change background and foreground colors of popups in your color scheme file.
Use 'popupBackground' or 'lineHighlight' or 'background' as background color.
'popupForeground' or 'foreground' as foreground color.

Closes #188.