### PR TITLE
Reload modules (no conflicts)

### DIFF
--- a/HaxeHelper.py
+++ b/HaxeHelper.py
@@ -12,13 +12,20 @@ import shlex
 import re
 
 
-
 def HaxeComplete_inst():
     try:  # Python 3
         from .HaxeComplete import HaxeComplete
     except (ValueError):  # Python 2
         from HaxeComplete import HaxeComplete
     return HaxeComplete.inst
+
+
+# Reload modules
+reloader = 'features.haxe_reload_modules'
+if sys.version_info >= (3,):
+    reloader = 'Haxe.' + reloader
+if reloader in sys.modules:
+    sys.modules[reloader].reload_modules()
 
 spaceChars = re.compile("\s")
 wordChars = re.compile("[a-z0-9._]", re.I)

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -14,6 +14,7 @@ from .haxe_extract_var import HaxeExtractVar
 from .haxe_hint import HaxeHint, HaxeShowPopup, HaxeColorScheme
 from .haxe_implement_interface import HaxeImplementInterface
 from .haxe_organize_imports import HaxeOrganizeImports, HaxeOrganizeImportsEventListener, HaxeOrganizeImportsEdit
+from .haxe_reload_modules import reload_modules
 
 print("Haxe : Reloading haxe module")
 
@@ -35,4 +36,5 @@ __all__ = [
     'HaxeColorScheme',
     'HaxeShowPopup',
     'HaxeHint',
+    'reload_modules',
 ]

--- a/features/haxe_create_type.py
+++ b/features/haxe_create_type.py
@@ -21,7 +21,7 @@ class HaxeCreateType( sublime_plugin.WindowCommand ):
         view = sublime.active_window().active_view()
         scopes = view.scope_name(view.sel()[0].end()).split()
         fn = view.file_name()
-            
+
         pack = [];
 
         if fn is None :
@@ -64,7 +64,7 @@ class HaxeCreateType( sublime_plugin.WindowCommand ):
 
     def on_done( self , inp ) :
 
-        fn = self.classpath;
+        fn = HaxeCreateType.classpath
         parts = inp.split(".")
         pack = []
         cl = "${2:ClassName}"

--- a/features/haxe_reload_modules.py
+++ b/features/haxe_reload_modules.py
@@ -1,0 +1,44 @@
+import sublime
+import sys
+
+if sys.version_info >= (3,):
+    from imp import reload
+
+haxe_modules = []
+for mod in sys.modules:
+    if 'haxe_' in mod and sys.modules[mod] != None:
+        haxe_modules.append(mod)
+
+
+package = 'features'
+if int(sublime.version()) >= 3000:
+    package = 'Haxe.' + package
+
+submods = [
+    '',
+    '.haxe_generate_code_helper',
+    '.haxe_organize_imports',
+    '.haxe_generate_field',
+    '.haxe_restart_server',
+    '.haxe_create_type',
+    '.haxe_generate_import',
+    '.haxe_find_definition',
+    '.haxe_show_type',
+    '.haxe_add_hxml',
+    '.haxe_extract_var',
+    '.haxe_implement_interface',
+    '.haxe_generate_code',
+    '.haxe_reload_modules',
+]
+
+def reload_modules():
+    print('Reload submods')
+    for submod in submods:
+        mod = package + submod
+        if mod in haxe_modules:
+            try:
+                reload(sys.modules[mod])
+                print('reload ', mod)
+            except:
+                print('pass ', mod)
+                pass


### PR DESCRIPTION
Reloads modules in *feature* package after *HaxeHelper.py* reload.

Closes #171.
PR fixes @genesisbryant's issue.
@kevinfiol's issue should be fixed in previous commits.