### PR TITLE
fixing regex and adding flags

### DIFF
--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -900,13 +900,35 @@
 		</dict>
 		<key>regex</key>
 		<dict>
+			<key>begin</key>
+			<string>~/</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>string.regexp.begin.haxe.2</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>/[gimsu]*</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>string.regexp.end.haxe.2</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.regexp.haxe.2</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
-					<string>~/((?:\\/|[^/])+)/[gimsu]*</string>
+					<string>\\.</string>
 					<key>name</key>
-					<string>string.regexp.haxe.2</string>
+					<string>constant.character.escape.haxe.2</string>
 				</dict>
 			</array>
 		</dict>

--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -159,6 +159,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#regex</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#arrays</string>
 				</dict>
 				<dict>
@@ -216,10 +220,6 @@
 				<dict>
 					<key>include</key>
 					<string>#punctuation-brackets</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#regex</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -904,7 +904,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>~/((?:\\/|[^/])+)/</string>
+					<string>~/((?:\\/|[^/])+)/[gimsu]*</string>
 					<key>name</key>
 					<string>string.regexp.haxe.2</string>
 				</dict>

--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -911,13 +911,18 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>/[gimsu]*</string>
+			<string>(/[gimsu]*)|(\n$)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>string.regexp.end.haxe.2</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.haxe.2</string>
 				</dict>
 			</dict>
 			<key>name</key>


### PR DESCRIPTION
Regex needs to be checked before strings and arrays because it can include all of those symbols. I also added regex flags to be highlighted and escape characters.