### PR TITLE
Whitespace at beginning of build output

### DIFF
--- a/Support/Hxml.sublime-build
+++ b/Support/Hxml.sublime-build
@@ -1,6 +1,6 @@
 {
 	"cmd": ["haxe" , "build.hxml"],
-	"file_regex": "^(.+):(\\d+): (?:lines \\d+-\\d+|character(?:s \\d+-| )(\\d+)) : (.*)$",
+	"file_regex": "^\\s*(.+):(\\d+): (?:lines \\d+-\\d+|character(?:s \\d+-| )(\\d+)) : (.*)$",
 	"working_dir": "${project_path:${folder:${file_path}}}",
 	"selector": "source.haxe.2,source.hxml"
 }


### PR DESCRIPTION
If there is whitespace at the beginning of a build line the file won't open and instead attempt to create a new file. The error can be recreated when building from munit.

```bash
# fails to open on double click
   source/Main.hx:141: characters 10-14 : Unknown identifier : foo

# works
source/Main.hx:166: characters 16-21 : Unknown identifier : bar
```