### PR TITLE
fixed empty multi-line comment (i.e. /**/) hightlighting

### DIFF
--- a/Haxe.tmLanguage
+++ b/Haxe.tmLanguage
@@ -233,7 +233,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(/\*+)</string>
+					<string>(/\*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -243,7 +243,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\*+/)</string>
+					<string>(\*/)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Before:
![screen shot 2015-06-19 at 6 07 48 am](https://cloud.githubusercontent.com/assets/103977/8243434/8cb601f2-1649-11e5-9a1a-a5c091472390.png)

After:
![screen shot 2015-06-19 at 6 07 05 am](https://cloud.githubusercontent.com/assets/103977/8243419/76b8f72e-1649-11e5-897c-bb897579a496.png)
