### PR TITLE
Fix "file changed on disk" error during autocomplete

### DIFF
--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -4,6 +4,8 @@ import sys
 #sys.path.append("/usr/lib/python2.6/")
 #sys.path.append("/usr/lib/python2.6/lib-dynload")
 
+from xml.sax.saxutils import escape
+
 import sublime, sublime_plugin
 import subprocess, time
 import tempfile
@@ -1781,7 +1783,7 @@ class HaxeComplete( sublime_plugin.EventListener ):
         mode = display["mode"]
 
         if int(sublime.version()) >= 3000 :
-            x = "<root>"+err+"</root>"
+            x = "<root>"+escape(err)+"</root>"
         else :
             x = "<root>"+err.encode("ASCII",'ignore')+"</root>"
 
@@ -2003,8 +2005,8 @@ class HaxeComplete( sublime_plugin.EventListener ):
         fn = view.file_name()
 
         if os.path.exists( temp ) :
-            if os.stat( temp )[stat.ST_MODE] & stat.S_IWRITE == 0:
-                os.chmod( temp , os.stat( temp )[stat.ST_MODE] | stat.S_IWRITE )
+            if getStatMode(temp) & stat.S_IWRITE == 0:
+                os.chmod( temp , getStatMode(temp) | stat.S_IWRITE )
 
             shutil.copy2( temp , fn )
             # os.chmod( temp, stat.S_IWRITE )

--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -30,6 +30,14 @@ if sys.version_info >= (3,):
 if reloader in sys.modules:
     sys.modules[reloader].reload_modules()
 
+IS_PY2 = sys.version_info[0] == 2
+
+def getStatMode(path):
+    if IS_PY2:
+        return os.stat( path ).st_mode
+    else:
+        return os.stat( path )[stat.ST_MODE]
+
 try: # Python 3
 
     # Import the features module, including the haxelib and key commands etc
@@ -1972,15 +1980,15 @@ class HaxeComplete( sublime_plugin.EventListener ):
 
         if os.path.exists( fn ):
             if os.path.exists( temp ):
-                if os.stat( temp ).st_mode & stat.S_IWRITE == 0:
-                    os.chmod( temp , os.stat( temp ).st_mode | stat.S_IWRITE )
+                if getStatMode(temp) & stat.S_IWRITE == 0:
+                    os.chmod( temp , getStatMode(temp) | stat.S_IWRITE )
                 shutil.copy2( temp , fn )
                 os.remove( temp )
             # copy saved file to temp for future restoring
             shutil.copy2( fn , temp )
 
-            if os.stat( fn ).st_mode & stat.S_IWRITE == 0:
-                os.chmod( fn , os.stat( fn ).st_mode | stat.S_IWRITE )
+            if getStatMode(fn) & stat.S_IWRITE == 0:
+                os.chmod( fn , getStatMode(fn) | stat.S_IWRITE )
         # write current source to file
         f = codecs.open( fn , "wb" , "utf-8" , "ignore" )
         f.write( src )
@@ -1995,8 +2003,8 @@ class HaxeComplete( sublime_plugin.EventListener ):
         fn = view.file_name()
 
         if os.path.exists( temp ) :
-            if os.stat( temp ).st_mode & stat.S_IWRITE == 0:
-                os.chmod( temp , os.stat( temp ).st_mode | stat.S_IWRITE )
+            if os.stat( temp )[stat.ST_MODE] & stat.S_IWRITE == 0:
+                os.chmod( temp , os.stat( temp )[stat.ST_MODE] | stat.S_IWRITE )
 
             shutil.copy2( temp , fn )
             # os.chmod( temp, stat.S_IWRITE )

--- a/HaxeComplete.py
+++ b/HaxeComplete.py
@@ -2133,11 +2133,12 @@ class HaxeComplete( sublime_plugin.EventListener ):
             hints = []
             haxeComps = []
 
-            if not self.type_completion_only:
-                temp = self.save_temp_file( view )
-                byte_offset = len(codecs.encode(src[0:offset], "utf-8"))
-                ret , haxeComps , status , hints , _ = self.run_haxe( view , { "filename" : fn , "offset" : byte_offset , "commas" : commas , "mode" : mode })
-                self.clear_temp_file( view , temp )
+            # TODO: Causing errors on macOS, might not be able to access filesystem here
+            # if not self.type_completion_only:
+            #     temp = self.save_temp_file( view )
+            #     byte_offset = len(codecs.encode(src[0:offset], "utf-8"))
+            #     ret , haxeComps , status , hints , _ = self.run_haxe( view , { "filename" : fn , "offset" : byte_offset , "commas" : commas , "mode" : mode })
+            #     self.clear_temp_file( view , temp )
 
             if (toplevelComplete and len(haxeComps) == 0 or
                     self.type_completion_only):


### PR DESCRIPTION
Add a helper function to discern between changed `os.stat()` api between Python 2 and 3. This should fix "Files changed on disk" popups during auto-complete in #272.

Reference:
- [`os.stat(pathname)[stat.ST_MODE]`](https://docs.python.org/3.0/library/stat.html) in Python 3
- [`os.stat(pathname).st_mode`](https://docs.python.org/2/library/stat.html) in Python 2